### PR TITLE
RTR-1-3: Update TokenHeader to utilize the Access Token.

### DIFF
--- a/test/src/main/java/org/folio/spring/test/mock/MockMvcConstant.java
+++ b/test/src/main/java/org/folio/spring/test/mock/MockMvcConstant.java
@@ -26,6 +26,11 @@ public class MockMvcConstant {
   private static final Logger logger = LoggerFactory.getLogger(MockMvcConstant.class);
 
   /**
+   * Provide the FOLIO Access Token cookie name.
+   */
+  public static final String ACCESS_TOKEN_NAME = "folioAccessToken";
+
+  /**
    * Provide "application/json" Content-Type.
    */
   public static final String APP_JSON = "application/json";

--- a/web/src/main/java/org/folio/spring/web/config/TokenResolverWebMvcConfig.java
+++ b/web/src/main/java/org/folio/spring/web/config/TokenResolverWebMvcConfig.java
@@ -10,12 +10,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class TokenResolverWebMvcConfig implements WebMvcConfigurer {
 
+  @Value("${okapi.auth.accessCookieName:folioAccessToken}")
+  private String accessCookieName;
+
   @Value("${okapi.auth.tokenHeaderName:X-Okapi-Token}")
   private String tokenHeaderName;
 
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
-    argumentResolvers.add(new TokenHeaderResolver(tokenHeaderName));
+    argumentResolvers.add(new TokenHeaderResolver(accessCookieName, tokenHeaderName));
   }
 
 }

--- a/web/src/main/java/org/folio/spring/web/resolver/TokenHeaderResolver.java
+++ b/web/src/main/java/org/folio/spring/web/resolver/TokenHeaderResolver.java
@@ -1,5 +1,7 @@
 package org.folio.spring.web.resolver;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import org.folio.spring.web.annotation.TokenHeader;
 import org.folio.spring.web.utility.AnnotationUtility;
 import org.springframework.core.MethodParameter;
@@ -7,12 +9,16 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.util.WebUtils;
 
 public final class TokenHeaderResolver implements HandlerMethodArgumentResolver {
 
+  private final String accessCookieName;
+
   private final String tenantHeaderName;
 
-  public TokenHeaderResolver(String tenantHeaderName) {
+  public TokenHeaderResolver(String accessCookieName, String tenantHeaderName) {
+    this.accessCookieName = accessCookieName;
     this.tenantHeaderName = tenantHeaderName;
   }
 
@@ -29,7 +35,10 @@ public final class TokenHeaderResolver implements HandlerMethodArgumentResolver 
     NativeWebRequest webRequest,
     WebDataBinderFactory binderFactory
   ) throws Exception {
-    return webRequest.getHeader(tenantHeaderName);
+    HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+    Cookie accessCookie = request == null ? null : WebUtils.getCookie(request, accessCookieName);
+
+    return accessCookie == null ? webRequest.getHeader(tenantHeaderName) : accessCookie.getValue();
   }
   // @formatter:on
 

--- a/web/src/test/java/org/folio/spring/web/resolver/TokenHeaderResolverTest.java
+++ b/web/src/test/java/org/folio/spring/web/resolver/TokenHeaderResolverTest.java
@@ -1,15 +1,23 @@
 package org.folio.spring.web.resolver;
 
+import static org.folio.spring.test.mock.MockMvcConstant.ACCESS_TOKEN_NAME;
+import static org.folio.spring.test.mock.MockMvcConstant.OKAPI_TOKEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
 import org.folio.spring.web.utility.AnnotationUtility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -22,17 +30,26 @@ import org.springframework.web.context.request.NativeWebRequest;
 @ExtendWith(SpringExtension.class)
 class TokenHeaderResolverTest {
 
+  private static final String ACCESS_TOKEN = "access_token";
+
+  private static final Cookie ACCESS_COOKIE = new Cookie(ACCESS_TOKEN_NAME, ACCESS_TOKEN);
+
+  private static final String OKAPI_TOKEN = "okapi_token";
+
   @Mock
   private MethodParameter parameter;
 
   @Mock
   private NativeWebRequest nativeWebRequest;
 
+  @Mock
+  private HttpServletRequest httpServletRequest;
+
   private TokenHeaderResolver tokenHeaderResolver;
 
   @BeforeEach
   void beforeEach() {
-    tokenHeaderResolver = new TokenHeaderResolver("TokenHeaderResolver");
+    tokenHeaderResolver = new TokenHeaderResolver(ACCESS_TOKEN_NAME, OKAPI_TOKEN);
   }
 
   @Test
@@ -57,15 +74,45 @@ class TokenHeaderResolverTest {
     }
   }
 
-  @Test
-  void resolveArgumentWorksTest() throws Exception {
-    String works = "works";
+  @ParameterizedTest
+  @MethodSource("provideRequestTokens")
+  void resolveArgumentWorksTest(Cookie cookie) throws Exception {
+    when(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).thenReturn(httpServletRequest);
 
-    when(nativeWebRequest.getHeader(anyString())).thenReturn(works);
+    if (cookie == null) {
+      when(nativeWebRequest.getHeader(anyString())).thenReturn(OKAPI_TOKEN);
+      when(httpServletRequest.getCookies()).thenReturn(null);
+    } else {
+      when(httpServletRequest.getCookies()).thenReturn(new Cookie[] { cookie });
+    }
 
     Object result = tokenHeaderResolver.resolveArgument(null, null, nativeWebRequest, null);
 
-    assertEquals(works, result);
+    assertEquals(cookie == null ? OKAPI_TOKEN : ACCESS_TOKEN, result);
+  }
+
+  @Test
+  void resolveArgumentWorksWithNullNativeRequestTest() throws Exception {
+    when(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).thenReturn(null);
+    when(nativeWebRequest.getHeader(anyString())).thenReturn(OKAPI_TOKEN);
+
+    Object result = tokenHeaderResolver.resolveArgument(null, null, nativeWebRequest, null);
+
+    assertEquals(OKAPI_TOKEN, result);
+  }
+
+  /**
+   * Helper function for parameterized test providing request tokens.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Cookie cookie (the cookie returned by the HttpServletRequest).
+   */
+  private static Stream<Arguments> provideRequestTokens() {
+    return Stream.of(
+      Arguments.of((Cookie) null),
+      Arguments.of(ACCESS_COOKIE)
+    );
   }
 
   private class FakeAnnotation implements Annotation {


### PR DESCRIPTION
Part of #1 .
Resolves #3 .

Add `okapi.auth.accessCookieName` configuration that defaults to `folioAccessToken`.
Extend `TokenHeaderResolver` to accept the newly added `okapi.auth.accessCookieName`.

Process the web request and return the Cookie, if found.
If the cookie is not found, then attempt to return the `X-Okapi-Tenant` header value.

Update the unit tests as appropriate.